### PR TITLE
Fixed version check and download location

### DIFF
--- a/fragments/labels/topazphoto.sh
+++ b/fragments/labels/topazphoto.sh
@@ -2,8 +2,8 @@ topazphoto|\
 topazphotoai)
     name="Topaz Photo AI"
     type="pkg"
-    appNewVersion=$(curl -fs https://community.topazlabs.com/c/photo-ai/photo-ai-releases/85 | grep  -o "raw-topic-link'>.*<" | grep -o "v.*<" | sed -E 's/[v|<]//g' | head -1)
-    downloadURL="https://downloads.topazlabs.com/deploy/TopazPhotoAI/${appNewVersion}/TopazPhotoAI-${appNewVersion}.pkg"
+    appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'photoVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
+    downloadURL="https://topazlabs.com/d/photo/latest/mac/full"
     archiveName="TopazPhotoAI-${appNewVersion}.pkg"
     expectedTeamID="3G3JE37ZHF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
❯ ./assemble.sh topazphoto
2025-03-19 16:42:50 : INFO  : topazphoto : Total items in argumentsArray: 0
2025-03-19 16:42:50 : INFO  : topazphoto : argumentsArray: 
2025-03-19 16:42:50 : REQ   : topazphoto : ################## Start Installomator v. 10.8beta, date 2025-03-19
2025-03-19 16:42:50 : INFO  : topazphoto : ################## Version: 10.8beta
2025-03-19 16:42:50 : INFO  : topazphoto : ################## Date: 2025-03-19
2025-03-19 16:42:50 : INFO  : topazphoto : ################## topazphoto
2025-03-19 16:42:50 : DEBUG : topazphoto : DEBUG mode 1 enabled.
2025-03-19 16:42:51 : INFO  : topazphoto : Reading arguments again: 
2025-03-19 16:42:51 : DEBUG : topazphoto : name=Topaz Photo AI
2025-03-19 16:42:51 : DEBUG : topazphoto : appName=
2025-03-19 16:42:51 : DEBUG : topazphoto : type=pkg
2025-03-19 16:42:51 : DEBUG : topazphoto : archiveName=TopazPhotoAI-3.5.2.pkg
2025-03-19 16:42:51 : DEBUG : topazphoto : downloadURL=https://topazlabs.com/d/photo/latest/mac/full
2025-03-19 16:42:51 : DEBUG : topazphoto : curlOptions=
2025-03-19 16:42:51 : DEBUG : topazphoto : appNewVersion=3.5.2
2025-03-19 16:42:51 : DEBUG : topazphoto : appCustomVersion function: Not defined
2025-03-19 16:42:51 : DEBUG : topazphoto : versionKey=CFBundleShortVersionString
2025-03-19 16:42:51 : DEBUG : topazphoto : packageID=
2025-03-19 16:42:51 : DEBUG : topazphoto : pkgName=
2025-03-19 16:42:51 : DEBUG : topazphoto : choiceChangesXML=
2025-03-19 16:42:51 : DEBUG : topazphoto : expectedTeamID=3G3JE37ZHF
2025-03-19 16:42:51 : DEBUG : topazphoto : blockingProcesses=
2025-03-19 16:42:51 : DEBUG : topazphoto : installerTool=
2025-03-19 16:42:51 : DEBUG : topazphoto : CLIInstaller=
2025-03-19 16:42:51 : DEBUG : topazphoto : CLIArguments=
2025-03-19 16:42:51 : DEBUG : topazphoto : updateTool=
2025-03-19 16:42:51 : DEBUG : topazphoto : updateToolArguments=
2025-03-19 16:42:51 : DEBUG : topazphoto : updateToolRunAsCurrentUser=
2025-03-19 16:42:51 : INFO  : topazphoto : BLOCKING_PROCESS_ACTION=tell_user
2025-03-19 16:42:51 : INFO  : topazphoto : NOTIFY=success
2025-03-19 16:42:51 : INFO  : topazphoto : LOGGING=DEBUG
2025-03-19 16:42:51 : INFO  : topazphoto : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-19 16:42:51 : INFO  : topazphoto : Label type: pkg
2025-03-19 16:42:51 : INFO  : topazphoto : archiveName: TopazPhotoAI-3.5.2.pkg
2025-03-19 16:42:51 : INFO  : topazphoto : no blocking processes defined, using Topaz Photo AI as default
2025-03-19 16:42:51 : DEBUG : topazphoto : Changing directory to /Users/pavel.kuzminov/code/Installomator-BN/build
2025-03-19 16:42:51 : INFO  : topazphoto : name: Topaz Photo AI, appName: Topaz Photo AI.app
2025-03-19 16:42:51 : WARN  : topazphoto : No previous app found
2025-03-19 16:42:51 : WARN  : topazphoto : could not find Topaz Photo AI.app
2025-03-19 16:42:51 : INFO  : topazphoto : appversion: 
2025-03-19 16:42:51 : INFO  : topazphoto : Latest version of Topaz Photo AI is 3.5.2
2025-03-19 16:42:51 : REQ   : topazphoto : Downloading https://topazlabs.com/d/photo/latest/mac/full to TopazPhotoAI-3.5.2.pkg
2025-03-19 16:42:51 : DEBUG : topazphoto : No Dialog connection, just download
2025-03-19 16:44:00 : INFO  : topazphoto : Downloaded TopazPhotoAI-3.5.2.pkg – Type is  xar archive compressed TOC – SHA is 5c0f808ad52cb714b9ec2cc12c8740bcf996ded8 – Size is 1212828 kB
2025-03-19 16:44:00 : DEBUG : topazphoto : DEBUG mode 1, not checking for blocking processes
2025-03-19 16:44:00 : REQ   : topazphoto : Installing Topaz Photo AI
2025-03-19 16:44:00 : INFO  : topazphoto : Verifying: TopazPhotoAI-3.5.2.pkg
2025-03-19 16:44:00 : DEBUG : topazphoto : File list: -rw-r--r--  1 pavel.kuzminov  AD\Domain Users   1.2G Mar 19 16:43 TopazPhotoAI-3.5.2.pkg
2025-03-19 16:44:00 : DEBUG : topazphoto : File type: TopazPhotoAI-3.5.2.pkg: xar archive compressed TOC: 6605, SHA-1 checksum
2025-03-19 16:44:00 : DEBUG : topazphoto : spctlOut is TopazPhotoAI-3.5.2.pkg: accepted
2025-03-19 16:44:00 : DEBUG : topazphoto : source=Notarized Developer ID
2025-03-19 16:44:00 : DEBUG : topazphoto : origin=Developer ID Installer: Topaz Labs, LLC (3G3JE37ZHF)
2025-03-19 16:44:00 : INFO  : topazphoto : Team ID: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2025-03-19 16:44:00 : DEBUG : topazphoto : DEBUG enabled, skipping installation
2025-03-19 16:44:00 : INFO  : topazphoto : Finishing...
2025-03-19 16:44:03 : INFO  : topazphoto : name: Topaz Photo AI, appName: Topaz Photo AI.app
2025-03-19 16:44:03 : WARN  : topazphoto : No previous app found
2025-03-19 16:44:03 : WARN  : topazphoto : could not find Topaz Photo AI.app
2025-03-19 16:44:03 : REQ   : topazphoto : Installed Topaz Photo AI, version 3.5.2
2025-03-19 16:44:03 : INFO  : topazphoto : notifying
2025-03-19 16:44:04 : DEBUG : topazphoto : DEBUG mode 1, not reopening anything
2025-03-19 16:44:04 : REQ   : topazphoto : All done!
2025-03-19 16:44:04 : REQ   : topazphoto : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
