### PR TITLE
Fix TopazVideoAI

### DIFF
--- a/fragments/labels/topazvideo.sh
+++ b/fragments/labels/topazvideo.sh
@@ -4,6 +4,5 @@ topazvideoai)
     type="dmg"
     appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'videoVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
     downloadURL="https://topazlabs.com/d/tvai/latest/mac/full"
-    archiveName="TopazVideoAI-${appNewVersion}.dmg"
     expectedTeamID="3G3JE37ZHF"
     ;;

--- a/fragments/labels/topazvideo.sh
+++ b/fragments/labels/topazvideo.sh
@@ -1,9 +1,9 @@
 topazvideo|\
 topazvideoai)
     name="Topaz Video AI"
-    type="pkg"
+    type="dmg"
     appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'videoVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
     downloadURL="https://topazlabs.com/d/tvai/latest/mac/full"
-    archiveName="TopazVideoAI-${appNewVersion}.pkg"
+    archiveName="TopazVideoAI-${appNewVersion}.dmg"
     expectedTeamID="3G3JE37ZHF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
❯ ./assemble.sh topazvideo
2025-04-02 13:16:06 : INFO  : topazvideo : Total items in argumentsArray: 0
2025-04-02 13:16:06 : INFO  : topazvideo : argumentsArray: 
2025-04-02 13:16:06 : REQ   : topazvideo : ################## Start Installomator v. 10.8beta, date 2025-04-02
2025-04-02 13:16:06 : INFO  : topazvideo : ################## Version: 10.8beta
2025-04-02 13:16:06 : INFO  : topazvideo : ################## Date: 2025-04-02
2025-04-02 13:16:06 : INFO  : topazvideo : ################## topazvideo
2025-04-02 13:16:06 : DEBUG : topazvideo : DEBUG mode 1 enabled.
2025-04-02 13:16:07 : INFO  : topazvideo : Reading arguments again: 
2025-04-02 13:16:07 : DEBUG : topazvideo : name=Topaz Video AI
2025-04-02 13:16:07 : DEBUG : topazvideo : appName=
2025-04-02 13:16:07 : DEBUG : topazvideo : type=dmg
2025-04-02 13:16:07 : DEBUG : topazvideo : archiveName=
2025-04-02 13:16:07 : DEBUG : topazvideo : downloadURL=https://topazlabs.com/d/tvai/latest/mac/full
2025-04-02 13:16:07 : DEBUG : topazvideo : curlOptions=
2025-04-02 13:16:07 : DEBUG : topazvideo : appNewVersion=6.1.3
2025-04-02 13:16:07 : DEBUG : topazvideo : appCustomVersion function: Not defined
2025-04-02 13:16:07 : DEBUG : topazvideo : versionKey=CFBundleShortVersionString
2025-04-02 13:16:07 : DEBUG : topazvideo : packageID=
2025-04-02 13:16:07 : DEBUG : topazvideo : pkgName=
2025-04-02 13:16:07 : DEBUG : topazvideo : choiceChangesXML=
2025-04-02 13:16:07 : DEBUG : topazvideo : expectedTeamID=3G3JE37ZHF
2025-04-02 13:16:07 : DEBUG : topazvideo : blockingProcesses=
2025-04-02 13:16:07 : DEBUG : topazvideo : installerTool=
2025-04-02 13:16:07 : DEBUG : topazvideo : CLIInstaller=
2025-04-02 13:16:07 : DEBUG : topazvideo : CLIArguments=
2025-04-02 13:16:07 : DEBUG : topazvideo : updateTool=
2025-04-02 13:16:07 : DEBUG : topazvideo : updateToolArguments=
2025-04-02 13:16:07 : DEBUG : topazvideo : updateToolRunAsCurrentUser=
2025-04-02 13:16:07 : INFO  : topazvideo : BLOCKING_PROCESS_ACTION=tell_user
2025-04-02 13:16:07 : INFO  : topazvideo : NOTIFY=success
2025-04-02 13:16:07 : INFO  : topazvideo : LOGGING=DEBUG
2025-04-02 13:16:07 : INFO  : topazvideo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-02 13:16:07 : INFO  : topazvideo : Label type: dmg
2025-04-02 13:16:07 : INFO  : topazvideo : archiveName: Topaz Video AI.dmg
2025-04-02 13:16:07 : INFO  : topazvideo : no blocking processes defined, using Topaz Video AI as default
2025-04-02 13:16:07 : DEBUG : topazvideo : Changing directory to /Users/pavel.kuzminov/code/Installomator-BN/build
2025-04-02 13:16:07 : INFO  : topazvideo : name: Topaz Video AI, appName: Topaz Video AI.app
2025-04-02 13:16:07 : WARN  : topazvideo : No previous app found
2025-04-02 13:16:08 : WARN  : topazvideo : could not find Topaz Video AI.app
2025-04-02 13:16:08 : INFO  : topazvideo : appversion: 
2025-04-02 13:16:08 : INFO  : topazvideo : Latest version of Topaz Video AI is 6.1.3
2025-04-02 13:16:08 : REQ   : topazvideo : Downloading https://topazlabs.com/d/tvai/latest/mac/full to Topaz Video AI.dmg
2025-04-02 13:16:08 : DEBUG : topazvideo : No Dialog connection, just download
2025-04-02 13:16:54 : INFO  : topazvideo : Downloaded Topaz Video AI.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is dcf50ca23d181329d2161184ffd0dc9d93e6eee3 – Size is 705020 kB
2025-04-02 13:16:54 : DEBUG : topazvideo : DEBUG mode 1, not checking for blocking processes
2025-04-02 13:16:54 : REQ   : topazvideo : Installing Topaz Video AI
2025-04-02 13:16:54 : INFO  : topazvideo : Mounting /Users/pavel.kuzminov/code/Installomator-BN/build/Topaz Video AI.dmg
2025-04-02 13:17:31 : DEBUG : topazvideo : Debugging enabled, dmgmount output was:
Beräknar kontrollsumma för Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verifierade   CRC32 $49B1D3F3
Beräknar kontrollsumma för GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verifierade   CRC32 $84849F2C
Beräknar kontrollsumma för GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verifierade   CRC32 $749F8FB9
Beräknar kontrollsumma för  (Apple_Free : 3)…
(Apple_Free : 3): verifierade   CRC32 $00000000
Beräknar kontrollsumma för EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verifierade   CRC32 $B54B659C
Beräknar kontrollsumma för disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verifierade   CRC32 $0DDD9A17
Beräknar kontrollsumma för  (Apple_Free : 6)…
(Apple_Free : 6): verifierade   CRC32 $00000000
Beräknar kontrollsumma för GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verifierade   CRC32 $749F8FB9
Beräknar kontrollsumma för GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verifierade   CRC32 $3690D69D
verifierade   CRC32 $1DB19C58
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Topaz Video AI 6.1.3

2025-04-02 13:17:31 : INFO  : topazvideo : Mounted: /Volumes/Topaz Video AI 6.1.3
2025-04-02 13:17:31 : INFO  : topazvideo : Verifying: /Volumes/Topaz Video AI 6.1.3/Topaz Video AI.app
2025-04-02 13:17:31 : DEBUG : topazvideo : App size: 1.9G	/Volumes/Topaz Video AI 6.1.3/Topaz Video AI.app
2025-04-02 13:18:24 : DEBUG : topazvideo : Debugging enabled, App Verification output was:
/Volumes/Topaz Video AI 6.1.3/Topaz Video AI.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Topaz Labs, LLC (3G3JE37ZHF)

2025-04-02 13:18:24 : INFO  : topazvideo : Team ID matching: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2025-04-02 13:18:24 : INFO  : topazvideo : Installing Topaz Video AI version 6.1.3 on versionKey CFBundleShortVersionString.
2025-04-02 13:18:24 : INFO  : topazvideo : App has LSMinimumSystemVersion: 10.14
2025-04-02 13:18:24 : DEBUG : topazvideo : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-04-02 13:18:24 : INFO  : topazvideo : Finishing...
2025-04-02 13:18:27 : INFO  : topazvideo : name: Topaz Video AI, appName: Topaz Video AI.app
2025-04-02 13:18:28 : WARN  : topazvideo : No previous app found
2025-04-02 13:18:28 : WARN  : topazvideo : could not find Topaz Video AI.app
2025-04-02 13:18:28 : REQ   : topazvideo : Installed Topaz Video AI, version 6.1.3
2025-04-02 13:18:28 : INFO  : topazvideo : notifying
2025-04-02 13:18:28 : DEBUG : topazvideo : Unmounting /Volumes/Topaz Video AI 6.1.3
2025-04-02 13:18:34 : DEBUG : topazvideo : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-04-02 13:18:34 : DEBUG : topazvideo : DEBUG mode 1, not reopening anything
2025-04-02 13:18:34 : REQ   : topazvideo : All done!
2025-04-02 13:18:34 : REQ   : topazvideo : ################## End Installomator, exit code 0 
```
