### PR TITLE
Update espanso

### DIFF
--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -9,6 +9,8 @@ espanso)
     else
         type="zip"
         downloadURL="https://github.com/espanso/espanso/releases/download/v2.2.1/Espanso-Mac-Intel.zip"
+        appNewVersion=2.2.1
         expectedTeamID="K839T4T5BY"
     fi
+    blockingProcesses=( "Espanso" "espanso" )
     ;;


### PR DESCRIPTION
Added `appNewVersion=2.2.1` to Intel, to prevent trying to download a 2.2.3 Intel version, since it's not there (yet) Put `blockingProcessess` back. 